### PR TITLE
Set and display logging level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@
 - tests folder
 - Basic howto on README.md
 - submission_from_csv endpoint and function to read csv files
-- Set logging level to debug
+- Add custom logging formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - tests folder
 - Basic howto on README.md
 - submission_from_csv endpoint and function to read csv files
+- Set logging level to debug

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ poetry install
 You can run an instance of the server by typing:
 
 ```
-uvicorn preClinVar.main:app --reload
+uvicorn preClinVar.main:app --reload --log-level debug 
 ```
 
 The server will run on localhost and default port 8000 (http://127.0.0.1:8000)

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -5,14 +5,18 @@ import uvicorn
 from fastapi import FastAPI, File, UploadFile
 from preClinVar.parse import csv_lines
 
-LOG = logging.getLogger("api")
-LOG.setLevel(logging.DEBUG)
-sh = logging.StreamHandler()
-sh.setLevel(logging.DEBUG)
-LOG.addHandler(sh)
+LOG = logging.getLogger("uvicorn.access")
 
 app = FastAPI()
 
+
+@app.on_event("startup")
+async def startup_event():
+    LOG = logging.getLogger("uvicorn.access")
+    console_formatter = uvicorn.logging.ColourizedFormatter(
+        "{levelprefix} {asctime} : {message}",
+        style="{", use_colors=True)
+    LOG.handlers[0].setFormatter(console_formatter)
 
 @app.get("/")
 async def root():

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -5,7 +5,11 @@ import uvicorn
 from fastapi import FastAPI, File, UploadFile
 from preClinVar.parse import csv_lines
 
-LOG = logging.getLogger(__name__)
+LOG = logging.getLogger("api")
+LOG.setLevel(logging.DEBUG)
+sh = logging.StreamHandler()
+sh.setLevel(logging.DEBUG)
+LOG.addHandler(sh)
 
 app = FastAPI()
 


### PR DESCRIPTION
### This PR adds | fixes:
- Print debug messages to console

### How to test:
- On main branch
- Run the demo app with this command: `uvicorn preClinVar.main:app --reload --log-level debug`
- Try the API by uploading Variants and CaseData files both using main branch and this branch

<img width="881" alt="image" src="https://user-images.githubusercontent.com/28093618/176622864-48785704-09aa-4926-b76e-f9fe4ceb2663.png">


### Expected outcome:
- [x] This branch should display the content of the parsed files, main branch shouldn't show anything

### Review:
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
