### PR TITLE
Parse all csv fields and create a dictionary according the the official submission schema

### DIFF
--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -3,7 +3,7 @@ from typing import List
 
 import uvicorn
 from fastapi import FastAPI, File, UploadFile
-from preClinVar.parse import csv_lines
+from preClinVar.parse import csv_lines, csv_fields_to_submission
 
 LOG = logging.getLogger("uvicorn.access")
 
@@ -44,7 +44,9 @@ async def submission_from_csv(files: List[UploadFile] = File(...)):
         else:
             variants_lines = file_lines
 
-    LOG.debug(f"Variant file contains the following lines:{variants_lines}")
-    LOG.debug(f"Casedata file contains the following lines:{casedata_lines}")
+    #LOG.debug(f"Variant file contains the following lines:{variants_lines}")
+    #LOG.debug(f"CaseData file contains the following lines:{casedata_lines}")
+
+    csv_fields_to_submission(variants_lines, casedata_lines)
 
     return {"message": "hello"}

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -3,7 +3,7 @@ from typing import List
 
 import uvicorn
 from fastapi import FastAPI, File, UploadFile
-from preClinVar.parse import csv_lines, csv_fields_to_submission
+from preClinVar.parse import csv_fields_to_submission, csv_lines
 
 LOG = logging.getLogger("uvicorn.access")
 
@@ -14,9 +14,10 @@ app = FastAPI()
 async def startup_event():
     LOG = logging.getLogger("uvicorn.access")
     console_formatter = uvicorn.logging.ColourizedFormatter(
-        "{levelprefix} {asctime} : {message}",
-        style="{", use_colors=True)
+        "{levelprefix} {asctime} : {message}", style="{", use_colors=True
+    )
     LOG.handlers[0].setFormatter(console_formatter)
+
 
 @app.get("/")
 async def root():
@@ -44,9 +45,10 @@ async def submission_from_csv(files: List[UploadFile] = File(...)):
         else:
             variants_lines = file_lines
 
-    #LOG.debug(f"Variant file contains the following lines:{variants_lines}")
-    #LOG.debug(f"CaseData file contains the following lines:{casedata_lines}")
+    # LOG.debug(f"Variant file contains the following lines:{variants_lines}")
+    # LOG.debug(f"CaseData file contains the following lines:{casedata_lines}")
 
-    csv_fields_to_submission(variants_lines, casedata_lines)
+    submission_dict = csv_fields_to_submission(variants_lines, casedata_lines)
+    assert submission_dict
 
     return {"message": "hello"}

--- a/preClinVar/parse.py
+++ b/preClinVar/parse.py
@@ -5,39 +5,69 @@ from tempfile import NamedTemporaryFile
 
 LOG = logging.getLogger("uvicorn.access")
 
-def set_item_assertion_criteria(item, line_dict):
+
+def set_item_assertion_criteria(item, variant_dict):
     """Set the assertionCriteria key/values for an API submission item
     Args:
         item(dict). An item in the clinvarSubmission.items list
-        line_dict(dict). Example: {'##Local ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Linking ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Gene symbol': 'XDH', 'Reference sequence': 'NM_000379.4', 'HGVS': 'c.2751del', ..}
+        variants_dict(dict). Example: {'##Local ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Linking ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Gene symbol': 'XDH', 'Reference sequence': 'NM_000379.4', 'HGVS': 'c.2751del', ..}
     """
     # Add CITATION key/value (a dict)
     citation = {}
-    asc = line_dict.get("Assertion method citation")
+    asc = variant_dict.get("Assertion method citation")
     if asc and ":" in asc:
         citation["db"] = asc.split(":")[0]
         citation["id"] = asc.split(":")[1]
 
     # Add method key/value (a string)
     method = ""
-    am = line_dict.get("Assertion method")
+    am = variant_dict.get("Assertion method")
     if am:
         method = am
 
-    item["assertionCriteria"] = {"citation":citation, "method": method}
+    item["assertionCriteria"] = {"citation": citation, "method": method}
 
-def set_item_clin_sign(item, line_dict):
+
+def set_item_clin_sig(item, variant_dict):
     """Set the clinicalSignificance key/values for an API submission item
     Args:
         item(dict). An item in the clinvarSubmission.items list
-        line_dict(dict). Example: {'##Local ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Linking ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Gene symbol': 'XDH', 'Reference sequence': 'NM_000379.4', 'HGVS': 'c.2751del', ..}
+        variant_dict(dict). Example: {'##Local ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Linking ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Gene symbol': 'XDH', 'Reference sequence': 'NM_000379.4', 'HGVS': 'c.2751del', ..}
     """
-    clinsig = line_dict.get("Clinical significance")
-    last_eval = line_dict.get("Date last evaluated")
+    clinsig = variant_dict.get("Clinical significance")
+    clinsig_comment = variant_dict.get("Comment on clinical significance")
+    last_eval = variant_dict.get("Date last evaluated")
+    inherit_mode = variant_dict.get("Mode of inheritance")
 
-    item["clinicalSignificance"] = {"clinicalSignificanceDescription" : clinsig}
+    item["clinicalSignificance"] = {"clinicalSignificanceDescription": clinsig}
+    if clinsig_comment:
+        item["clinicalSignificance"]["comment"] = clinsig_comment
     if last_eval:
         item["clinicalSignificance"]["dateLastEvaluated"] = last_eval
+    if inherit_mode:
+        item["clinicalSignificance"]["modeOfInheritance"] = inherit_mode
+
+
+def set_item_condition_set(item, variant_dict):
+    """Set the conditionSet key/values for an API submission item
+    Args:
+        item(dict). An item in the clinvarSubmission.items list
+        variant_dict(dict). Example: {'##Local ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Linking ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Gene symbol': 'XDH', 'Reference sequence': 'NM_000379.4', 'HGVS': 'c.2751del', ..}
+    """
+    conditions = []
+
+    # Check if phenotype was specified in Variant file or in CaseData file
+    cond_dbs = variant_dict.get("Condition ID type")
+    cond_values = variant_dict.get("Condition ID value")
+
+    if cond_dbs and cond_values:
+        cond_dbs = cond_dbs.split(";")
+        cond_values = cond_values.split(";")
+        for cond_n, cond_db in enumerate(cond_dbs):
+            conditions.append({"db": cond_db, "id": cond_values[cond_n]})
+    if conditions:
+        item["conditionSet"] = {"condition": conditions}
+
 
 def csv_fields_to_submission(variants_lines, casedata_lines):
     """Create a dictionary corresponding to a json submission file
@@ -51,38 +81,27 @@ def csv_fields_to_submission(variants_lines, casedata_lines):
         subm_dict(dict): a json submission dictionary formatted according to this schema:
         https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/
     """
-    clinvar_submission = {"title": "ClinVar Submission Set"} # The main ClinVar submission dictionary
+    clinvar_submission = {
+        "title": "ClinVar Submission Set"
+    }  # The main ClinVar submission dictionary
     items = []
     # Loop over the variants to submit and create a
-    for line_dict in variants_lines:
+    for linen, line_dict in enumerate(variants_lines):
+
         LOG.error(line_dict)
 
-        item = {} # For each variant in the csv file (one line), create a submission item
+        item = {}  # For each variant in the csv file (one line), create a submission item
 
         set_item_assertion_criteria(item, line_dict)
-
-        set_item_clin_sign(item, line_dict)
-
+        set_item_clin_sig(item, line_dict)
+        set_item_condition_set(item, line_dict)
 
         items.append(item)
-
-
 
     clinvar_submission["items"] = items
 
     for item in clinvar_submission["items"]:
-        LOG.debug(str(item)+"\n")
-
-
-
-
-
-
-
-
-
-
-
+        LOG.debug(str(item) + "\n")
 
 
 async def csv_lines(csv_file):

--- a/preClinVar/parse.py
+++ b/preClinVar/parse.py
@@ -3,7 +3,86 @@ import os
 from csv import DictReader
 from tempfile import NamedTemporaryFile
 
-LOG = logging.getLogger(__name__)
+LOG = logging.getLogger("uvicorn.access")
+
+def set_item_assertion_criteria(item, line_dict):
+    """Set the assertionCriteria key/values for an API submission item
+    Args:
+        item(dict). An item in the clinvarSubmission.items list
+        line_dict(dict). Example: {'##Local ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Linking ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Gene symbol': 'XDH', 'Reference sequence': 'NM_000379.4', 'HGVS': 'c.2751del', ..}
+    """
+    # Add CITATION key/value (a dict)
+    citation = {}
+    asc = line_dict.get("Assertion method citation")
+    if asc and ":" in asc:
+        citation["db"] = asc.split(":")[0]
+        citation["id"] = asc.split(":")[1]
+
+    # Add method key/value (a string)
+    method = ""
+    am = line_dict.get("Assertion method")
+    if am:
+        method = am
+
+    item["assertionCriteria"] = {"citation":citation, "method": method}
+
+def set_item_clin_sign(item, line_dict):
+    """Set the clinicalSignificance key/values for an API submission item
+    Args:
+        item(dict). An item in the clinvarSubmission.items list
+        line_dict(dict). Example: {'##Local ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Linking ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Gene symbol': 'XDH', 'Reference sequence': 'NM_000379.4', 'HGVS': 'c.2751del', ..}
+    """
+    clinsig = line_dict.get("Clinical significance")
+    last_eval = line_dict.get("Date last evaluated")
+
+    item["clinicalSignificance"] = {"clinicalSignificanceDescription" : clinsig}
+    if last_eval:
+        item["clinicalSignificance"]["dateLastEvaluated"] = last_eval
+
+def csv_fields_to_submission(variants_lines, casedata_lines):
+    """Create a dictionary corresponding to a json submission file
+       from the fields present in Variant and CaseData csv files
+
+    Args:
+        variants_lines(list of dicts). [{'##Local ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Linking ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Gene symbol': 'XDH', 'Reference sequence': 'NM_000379.4', ..}, {..}]
+        casedata_lines(list of dicts). Example:
+
+    Returns:
+        subm_dict(dict): a json submission dictionary formatted according to this schema:
+        https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/
+    """
+    clinvar_submission = {"title": "ClinVar Submission Set"} # The main ClinVar submission dictionary
+    items = []
+    # Loop over the variants to submit and create a
+    for line_dict in variants_lines:
+        LOG.error(line_dict)
+
+        item = {} # For each variant in the csv file (one line), create a submission item
+
+        set_item_assertion_criteria(item, line_dict)
+
+        set_item_clin_sign(item, line_dict)
+
+
+        items.append(item)
+
+
+
+    clinvar_submission["items"] = items
+
+    for item in clinvar_submission["items"]:
+        LOG.debug(str(item)+"\n")
+
+
+
+
+
+
+
+
+
+
+
 
 
 async def csv_lines(csv_file):

--- a/preClinVar/parse.py
+++ b/preClinVar/parse.py
@@ -138,7 +138,21 @@ def set_item_variant_set(item, variant_dict):
         variant_dict(dict). Example: {'##Local ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Linking ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Gene symbol': 'XDH', 'Reference sequence': 'NM_000379.4', 'HGVS': 'c.2751del', ..}
 
     """
-    pass
+    # According the schema: The interpreted variant must be described either by HGVS or by chromosome coordinates, but not both.
+    # Our cvs files contain HGVS so we parse only these at the moment
+    item["variantSet"] = {}
+    variant = {"hgvs": variant_dict.get("HGVS")}
+
+    if variant_dict.get("Gene symbol"):
+        variant["gene"] = variant_dict.get("Gene symbol").split(";")
+
+    # NOT parsing the following key/values for now:
+    # variant.chromosomeCoordinates
+    # variant.copyNumber
+    # variant.gene.id
+    # variant.referenceCopyNumber
+
+    item["variantSet"]["variant"] = [variant]
 
 
 def csv_fields_to_submission(variants_lines, casedata_lines):
@@ -161,9 +175,6 @@ def csv_fields_to_submission(variants_lines, casedata_lines):
     # Loop over the variants to submit and create a
     for linen, line_dict in enumerate(variants_lines):
 
-        LOG.error(line_dict)
-        LOG.warning(casedata_lines[linen])
-
         item = {}  # For each variant in the csv file (one line), create a submission item
 
         set_item_assertion_criteria(item, line_dict)
@@ -182,6 +193,8 @@ def csv_fields_to_submission(variants_lines, casedata_lines):
 
     for item in clinvar_submission["items"]:
         LOG.debug(str(item) + "\n")
+
+    return clinvar_submission
 
 
 async def csv_lines(csv_file):


### PR DESCRIPTION
### This PR adds | fixes:
- [ ] Parse both Variant and CaseData csv files and create a dictionary submission object
- [ ] Validate the submission object dictionary against [the schema](https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/)

fix #4 

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
