### PR TITLE
Added proxy endpoint to ClinVar API submission dry run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - Add custom logging formatting
 - Tests and coverage GitHub workflow
 - Updated submission schema in resources following new release of schema by ClinVar (draft-07)
+- Proxy endpoint to interrogate the submission dry run endpoint of ClinVar API

--- a/preClinVar/build.py
+++ b/preClinVar/build.py
@@ -1,0 +1,14 @@
+def build_header(api_key):
+    """Creates a header to be submitted a in a POST rquest to the CLinVar API
+
+    Args:
+        api_key(str): API key to be used to submit to ClinVar (64 alphanumeric characters)
+
+    Returns:
+        header(dict): contains "Content-type: application/json" and "SP-API-KEY: <API-KEY>" key/values
+    """
+    header = {
+        "Content-Type": "application/json",
+        "SP-API-KEY": api_key,
+    }
+    return header

--- a/preClinVar/constants.py
+++ b/preClinVar/constants.py
@@ -1,1 +1,3 @@
-DRY_RUN_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true"
+DRY_RUN_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true"
+
+VALIDATE_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/apitest/v1/submissions"

--- a/preClinVar/demo/__init__.py
+++ b/preClinVar/demo/__init__.py
@@ -7,3 +7,7 @@ variants_csv = "SUB9282350_2022-06-28.Variant.csv"
 ###### Path to .csv files ######
 casedata_csv_path = pkg_resources.resource_filename("preClinVar", "/".join(["demo", casedata_csv]))
 variants_csv_path = pkg_resources.resource_filename("preClinVar", "/".join(["demo", variants_csv]))
+
+###### Example of a json file submission ######
+subm_json = "submission.json"
+subm_json_path = pkg_resources.resource_filename("preClinVar", "/".join(["demo", subm_json]))

--- a/preClinVar/demo/submission.json
+++ b/preClinVar/demo/submission.json
@@ -1,0 +1,156 @@
+{
+  "clinvarSubmission": [
+    {
+      "assertionCriteria": {
+        "citation": {
+          "db": "PubMed",
+          "id": "25741868"
+        },
+        "method": "ACMG Guidelines, 2015"
+      },
+      "clinicalSignificance": {
+        "clinicalSignificanceDescription": "Pathogenic",
+        "dateLastEvaluated": "2021-03-12",
+        "modeOfInheritance": "Autosomal recessive inheritance"
+      },
+      "conditionSet": {
+        "condition": [
+          {
+            "db": "OMIM",
+            "id": "278300"
+          }
+        ]
+      },
+      "localID": "1d9ce6ebf2f82d913cfbe20c5085947b",
+      "localKey": "1d9ce6ebf2f82d913cfbe20c5085947b",
+      "recordStatus": "novel",
+      "releaseStatus": "public",
+      "variantSet": {
+        "variant": [
+          {
+            "hgvs": "c.2751del",
+            "gene": [
+              {
+                "symbol": "XDH"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "assertionCriteria": {
+        "citation": {
+          "db": "PubMed",
+          "id": "25741868"
+        },
+        "method": "ACMG Guidelines, 2015"
+      },
+      "clinicalSignificance": {
+        "clinicalSignificanceDescription": "Pathogenic",
+        "dateLastEvaluated": "2021-03-16",
+        "modeOfInheritance": "Autosomal recessive inheritance"
+      },
+      "conditionSet": {
+        "condition": [
+          {
+            "db": "OMIM",
+            "id": "606054"
+          }
+        ]
+      },
+      "localID": "69b138a4c5caf211d796a59a7b46e40d",
+      "localKey": "69b138a4c5caf211d796a59a7b46e40d",
+      "recordStatus": "novel",
+      "releaseStatus": "public",
+      "variantSet": {
+        "variant": [
+          {
+            "hgvs": "c.2040G>A",
+            "gene": [
+              {
+                "symbol": "PCCA"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "assertionCriteria": {
+        "citation": {
+          "db": "PubMed",
+          "id": "25741868"
+        },
+        "method": "ACMG Guidelines, 2015"
+      },
+      "clinicalSignificance": {
+        "clinicalSignificanceDescription": "Pathogenic",
+        "dateLastEvaluated": "2021-03-12",
+        "modeOfInheritance": "Autosomal recessive inheritance"
+      },
+      "conditionSet": {
+        "condition": [
+          {
+            "db": "OMIM",
+            "id": "250100"
+          }
+        ]
+      },
+      "localID": "e1bdbf66cd8df98d0d6874a9c4a0d7bc",
+      "localKey": "e1bdbf66cd8df98d0d6874a9c4a0d7bc",
+      "recordStatus": "novel",
+      "releaseStatus": "public",
+      "variantSet": {
+        "variant": [
+          {
+            "hgvs": "c.465+1G>A",
+            "gene": [
+              {
+                "symbol": "ARSA"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "assertionCriteria": {
+        "citation": {
+          "db": "PubMed",
+          "id": "25741868"
+        },
+        "method": "ACMG Guidelines, 2015"
+      },
+      "clinicalSignificance": {
+        "clinicalSignificanceDescription": "Pathogenic",
+        "dateLastEvaluated": "2021-03-12",
+        "modeOfInheritance": "Autosomal recessive inheritance"
+      },
+      "conditionSet": {
+        "condition": [
+          {
+            "db": "OMIM",
+            "id": "251000"
+          }
+        ]
+      },
+      "localID": "ace28c419a620040c49be5ec9cb7ba37",
+      "localKey": "ace28c419a620040c49be5ec9cb7ba37",
+      "recordStatus": "novel",
+      "releaseStatus": "public",
+      "variantSet": {
+        "variant": [
+          {
+            "hgvs": "c.278G>A",
+            "gene": [
+              {
+                "symbol": "MMUT"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,16 @@
 from fastapi.testclient import TestClient
-from preClinVar.demo import casedata_csv, casedata_csv_path, variants_csv, variants_csv_path
+from preClinVar.demo import (
+    casedata_csv,
+    casedata_csv_path,
+    subm_json_path,
+    variants_csv,
+    variants_csv_path,
+)
 from preClinVar.main import app
 
 client = TestClient(app)
+
+DEMO_API_KEY = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
 
 
 def test_heartbeat():
@@ -25,3 +33,14 @@ def test_csv_2_json_missing_file():
 
     response = client.post("/csv_2_json", files=files)
     assert response.status_code == 200
+
+
+def test_dry_run_wrong_api_key():
+    """Test endpoint that sends a request to the ClinVar dry run API endpoint"""
+    json_file = {"json_file": open(subm_json_path, "rb")}
+
+    url = "?api_key=".join(["/dry-run", DEMO_API_KEY])
+
+    response = client.post(url, files=json_file)
+    assert response.status_code == 200
+    assert response.json()["message"] == "No valid API key provided"


### PR DESCRIPTION
### This PR adds | fixes:
ClinVar API has an endpoint to submit as dry runs: `https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true`

This is a proxy to that endpoint. This will allow to test what are the required params and file formats to send to the ClinVar API to achieve a successful submission

### How to test:
- I've included an automatic tests which will submit an invalid api key
- Test the API from http://127.0.0.1:8000/docs#/default/dry_run_dry_run_post with a valid api key and makes sure ClinVar API responds (it should say that the json submission is not valid)

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
