### PR TITLE
Fix requests in proxy endpoints and parsing of observedIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 - Tests and coverage GitHub workflow
 - Updated submission schema in resources following new release of schema by ClinVar (draft-07)
 - Proxy endpoint to interrogate the submission dry run endpoint of ClinVar API
+- Proxy endpoint to interrogate the submission validate endpoint of ClinVar API

--- a/preClinVar/constants.py
+++ b/preClinVar/constants.py
@@ -1,3 +1,2 @@
 DRY_RUN_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true"
-
 VALIDATE_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/apitest/v1/submissions"

--- a/preClinVar/demo/submission.json
+++ b/preClinVar/demo/submission.json
@@ -23,6 +23,13 @@
       },
       "localID": "1d9ce6ebf2f82d913cfbe20c5085947b",
       "localKey": "1d9ce6ebf2f82d913cfbe20c5085947b",
+      "observedIn": [
+        {
+          "affectedStatus": "yes",
+          "alleleOrigin": "germline",
+          "collectionMethod": "clinical testing"
+        }
+      ],
       "recordStatus": "novel",
       "releaseStatus": "public",
       "variantSet": {
@@ -61,6 +68,13 @@
       },
       "localID": "69b138a4c5caf211d796a59a7b46e40d",
       "localKey": "69b138a4c5caf211d796a59a7b46e40d",
+      "observedIn": [
+        {
+          "affectedStatus": "yes",
+          "alleleOrigin": "germline",
+          "collectionMethod": "clinical testing"
+        }
+      ],
       "recordStatus": "novel",
       "releaseStatus": "public",
       "variantSet": {
@@ -99,6 +113,13 @@
       },
       "localID": "e1bdbf66cd8df98d0d6874a9c4a0d7bc",
       "localKey": "e1bdbf66cd8df98d0d6874a9c4a0d7bc",
+      "observedIn": [
+        {
+          "affectedStatus": "yes",
+          "alleleOrigin": "germline",
+          "collectionMethod": "clinical testing"
+        }
+      ],
       "recordStatus": "novel",
       "releaseStatus": "public",
       "variantSet": {
@@ -137,6 +158,13 @@
       },
       "localID": "ace28c419a620040c49be5ec9cb7ba37",
       "localKey": "ace28c419a620040c49be5ec9cb7ba37",
+      "observedIn": [
+        {
+          "affectedStatus": "yes",
+          "alleleOrigin": "germline",
+          "collectionMethod": "clinical testing"
+        }
+      ],
       "recordStatus": "novel",
       "releaseStatus": "public",
       "variantSet": {

--- a/preClinVar/parse.py
+++ b/preClinVar/parse.py
@@ -114,6 +114,8 @@ def set_item_observed_in(item, casedata_dict):
     if casedata_dict.get("Clinical features"):
         obs_in["clinicalFeatures"] = casedata_dict.get("Clinical features").split(";")
 
+    item["observedIn"] = [obs_in]
+
     # NOT parsing the following key/values for now:
     # clinicalFeaturesComment
     # numberOfIndividuals

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,3 +44,14 @@ def test_dry_run_wrong_api_key():
     response = client.post(url, files=json_file)
     assert response.status_code == 200
     assert response.json()["message"] == "No valid API key provided"
+
+
+def test_validate_wrong_api_key():
+    """Test endpoint that sends a request to the ClinVar dry run API endpoint"""
+    json_file = {"json_file": open(subm_json_path, "rb")}
+
+    url = "?api_key=".join(["/validate", DEMO_API_KEY])
+
+    response = client.post(url, files=json_file)
+    assert response.status_code == 200
+    assert response.json()["message"] == "No valid API key provided"


### PR DESCRIPTION
### This PR adds | fixes:
- Fixes parsing of csv files that was not capturing `observedIn` key/values (fix #16)
- Added the proxy endpoint to submission validate (fix #12, fix #5)
- Fixed proxy endpoint to submit the right request data

### How to test:
- GitHub actions test submission endpoints with no valid api key. Tests should pass
- Manually test both proxy endpoints with a valid api key and the fixed sdemo ubmission object

### Expected outcome:
- Both endpoint should return success and a submission number (example SUB:XXXXXXX)

### Review:
-  [x] Tests executed by GitHub actions, CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
