### PR TITLE
Fix parsing of CaseData csv with more than one individuals associated to the same variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - submission_from_csv endpoint and function to read csv files
 - Add custom logging formatting
 - Tests and coverage GitHub workflow
-- Updated submission schema in resources following new release of schema by ClinVar (draft-07)
 - Proxy endpoint to interrogate the submission dry run endpoint of ClinVar API
 - Proxy endpoint to interrogate the submission validate endpoint of ClinVar API
+### Changed
+- Updated submission schema in resources following new release of schema by ClinVar (draft-07)
+### Fixed
+- Parsing of CaseData csv with more than one individuals associated to the same variant

--- a/preClinVar/demo/SUB9282350_2022-06-28.CaseData.csv
+++ b/preClinVar/demo/SUB9282350_2022-06-28.CaseData.csv
@@ -1,7 +1,7 @@
 "Linking ID","Individual ID","Collection method","Allele origin","Affected status","Sex","Family history","Proband","Secondary finding","Mosaicism","Zygosity","Platform type","Platform name","Method purpose","Date variant was reported to submitter"
 "7b7a372ea54e1c0de9ec6af4ebebd14a","20210316-01","clinical testing","germline","yes","female","no","yes","no","no","homozygote","next-gen sequencing","Whole genome sequencing, Illumina","discovery","2017-05-18"
 "1d9ce6ebf2f82d913cfbe20c5085947b","20210316-02","clinical testing","germline","yes","male","no","yes","no","no","homozygote","next-gen sequencing","Whole genome sequencing, Illumina","discovery","2019-09-18"
-"ce94e640e813c1cc6f4b9a20dd2811f1","20210323-04","clinical testing","germline","yes","male","no","yes","no","no","homozygote","next-gen sequencing","Whole genome sequencing, Illumina","discovery","2017-10-17"
 "69b138a4c5caf211d796a59a7b46e40d","20210316-03","clinical testing","germline","yes","male","no","yes","no","no","homozygote","next-gen sequencing","Whole genome sequencing, Illumina","discovery","2018-01-10"
 "e1bdbf66cd8df98d0d6874a9c4a0d7bc","20210316-04","clinical testing","germline","yes","male","no","yes","no","no","homozygote","next-gen sequencing","Whole genome sequencing, Illumina","discovery","2020-09-01"
 "ace28c419a620040c49be5ec9cb7ba37","20210316-05","clinical testing","germline","yes","male","no","yes","no","no","homozygote","next-gen sequencing","Whole genome sequencing, Illumina","discovery","2019-03-20"
+"ace28c419a620040c49be5ec9cb7ba37","20210316-05","clinical testing","germline","yes","female","no","yes","no","no","heterozygote","next-gen sequencing","Whole genome sequencing, Illumina","discovery","2019-03-20"

--- a/preClinVar/demo/submission.json
+++ b/preClinVar/demo/submission.json
@@ -163,6 +163,11 @@
           "affectedStatus": "yes",
           "alleleOrigin": "germline",
           "collectionMethod": "clinical testing"
+        },
+        {
+          "affectedStatus": "yes",
+          "alleleOrigin": "germline",
+          "collectionMethod": "clinical testing"
         }
       ],
       "recordStatus": "novel",

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, File, Query, UploadFile
 from fastapi.responses import JSONResponse
 from preClinVar.build import build_header
 from preClinVar.constants import DRY_RUN_SUBMISSION_URL, VALIDATE_SUBMISSION_URL
-from preClinVar.parse import csv_fields_to_submission, csv_lines
+from preClinVar.csv_parser import csv_fields_to_submission, csv_lines
 from preClinVar.validate import validate_submission
 from pydantic import BaseModel, Field
 
@@ -71,7 +71,10 @@ async def dry_run(
 
 @app.post("/csv_2_json")
 async def csv_2_json(files: List[UploadFile] = File(...)):
-    """Create and validate a json submission object using 2 CSV files (Variant.csv and CaseData.csv)"""
+    """Create a json submission object using 2 CSV files (Variant.csv and CaseData.csv).
+    Validate the submission objects agains the official schema:
+    https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/
+    """
 
     # Extract lines from Variants.csv and Casedata.csv files present in POST request
     casedata_lines = None


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #18

### How to test:
- Use the docs brrowser endpoint and load the both csv files, including the modified casedata (that now contains 2 individuals associated to the same variant)

### Expected outcome:
- When the json submission object is created, it should contain 2 individuals associated to the last variant (ace28c419a620040c49be5ec9cb7ba37)

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
