### PR TITLE
Fix dry run endpoint when ClinVar returns an empty 204 response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 - Improved README files with description of endpoints and how to test it
 ### Fixed
 - Parsing of CaseData csv with more than one individuals associated to the same variant
+- dry-run enpoint, to return success when ClinVar returns a 204 successful response

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -47,7 +47,10 @@ async def validate(
         "actions": [{"type": "AddData", "targetDb": "clinvar", "data": {"content": submission_obj}}]
     }
     resp = requests.post(VALIDATE_SUBMISSION_URL, data=json.dumps(data), headers=header)
-    return resp.json()
+    return JSONResponse(
+        status_code=resp.status_code,
+        content=resp.json(),
+    )
 
 
 @app.post("/dry-run")
@@ -70,7 +73,7 @@ async def dry_run(
     # A successful response will be an empty response with code 204
     if resp.status_code == 204:
         return JSONResponse(
-            status_code=200,
+            status_code=resp.status_code,
             content={"message": "success"},
         )
     return JSONResponse(

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -75,7 +75,7 @@ async def dry_run(
         )
     return JSONResponse(
         status_code=resp.status_code,
-        content={"message": "submission failed"},
+        content=resp.json(),
     )
 
 

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -73,7 +73,7 @@ async def dry_run(
     # A successful response will be an empty response with code 204
     if resp.status_code == 204:
         return JSONResponse(
-            status_code=resp.status_code,
+            status_code=200,
             content={"message": "success"},
         )
     return JSONResponse(

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -66,7 +66,17 @@ async def dry_run(
         "actions": [{"type": "AddData", "targetDb": "clinvar", "data": {"content": submission_obj}}]
     }
     resp = requests.post(DRY_RUN_SUBMISSION_URL, data=json.dumps(data), headers=header)
-    return resp.json()
+
+    # A successful response will be an empty response with code 204
+    if resp.status_code == 204:
+        return JSONResponse(
+            status_code=200,
+            content={"message": "success"},
+        )
+    return JSONResponse(
+        status_code=resp.status_code,
+        content={"message": "submission failed"},
+    )
 
 
 @app.post("/csv_2_json")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,5 +53,5 @@ def test_validate_wrong_api_key():
     url = "?api_key=".join(["/validate", DEMO_API_KEY])
 
     response = client.post(url, files=json_file)
-    assert response.status_code == 200
+    assert response.status_code == 401  # Not authorized
     assert response.json()["message"] == "No valid API key provided"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,7 +42,7 @@ def test_dry_run_wrong_api_key():
     url = "?api_key=".join(["/dry-run", DEMO_API_KEY])
 
     response = client.post(url, files=json_file)
-    assert response.status_code == 200
+    assert response.status_code == 401  # Not authorized
     assert response.json()["message"] == "No valid API key provided"
 
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #23 

According to the [ClinVar documentation](https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/#http_return_codes), a successful dry run submission returns empty content ({}) and 204 code.

<img width="806" alt="image" src="https://user-images.githubusercontent.com/28093618/177972617-90f25c09-b84a-484e-8d2a-b6c39dd80789.png">
 
My code tries to return json data from this empty response and that's why the bug happens


### How to test:
- Try the dry run endpoint with a valid api key and submission object

### Expected outcome:
- The endpoint should now return 200 (success) with a message

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
