### PR TITLE
Pass api key as form field and not query arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Updated submission schema in resources following new release of schema by ClinVar (draft-07)
 - Improved README files with description of endpoints and how to test it
 - Increased test coverage
+- Pass ClinVar API KEY as a form field and not a query argument
 ### Fixed
 - Parsing of CaseData csv with more than one individuals associated to the same variant
 - dry-run enpoint, to return success when ClinVar returns a 204 successful response

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -4,13 +4,12 @@ from typing import List
 
 import requests
 import uvicorn
-from fastapi import FastAPI, File, Query, UploadFile
+from fastapi import FastAPI, File, Form, UploadFile
 from fastapi.responses import JSONResponse
 from preClinVar.build import build_header
 from preClinVar.constants import DRY_RUN_SUBMISSION_URL, VALIDATE_SUBMISSION_URL
 from preClinVar.csv_parser import csv_fields_to_submission, csv_lines
 from preClinVar.validate import validate_submission
-from pydantic import BaseModel, Field
 
 LOG = logging.getLogger("uvicorn.access")
 
@@ -32,9 +31,7 @@ async def root():
 
 
 @app.post("/validate")
-async def validate(
-    api_key: str = Query(max_length=64, min_length=64), json_file: UploadFile = File(...)
-):
+async def validate(api_key: str = Form(), json_file: UploadFile = File(...)):
     """A proxy to the validate submission ClinVar API endpoint"""
     # Create a submission header
     header = build_header(api_key)
@@ -54,9 +51,7 @@ async def validate(
 
 
 @app.post("/dry-run")
-async def dry_run(
-    api_key: str = Query(max_length=64, min_length=64), json_file: UploadFile = File(...)
-):
+async def dry_run(api_key: str = Form(), json_file: UploadFile = File(...)):
     """A proxy to the dry run submission ClinVar API endpoint"""
     # Create a submission header
     header = build_header(api_key)


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #19

### How to test:
- On the swagger docs, api_key should be passed in the request body, and not as a parameter


### Review:
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
