### PR TITLE
Fixed Dockerfile command that prevented image to be pushed to Docker Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [unreleased]
+- Fixed Dockerfile building error resulting in prod image release failed to be pushed to Docker Hub 
+
 ## [1.0]
 ### Added
 - Poetry install
@@ -15,7 +18,6 @@
 - Docker-compose file
 - GitHub actions to build Docker images (prod and stage) and push them to Docker Hub
 - Codecov coverage badge
-- Version number in CHANGELOG file and heartbeat endpoint
 ### Changed
 - Updated submission schema in resources following new release of schema by ClinVar (draft-07)
 - Improved README files with description of endpoints and how to test it

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="/home/worker/venv/bin:$PATH"
 
 # install requirements
 RUN pip install poetry
-COPY poetry.lock pyproject.toml .
+COPY poetry.lock pyproject.toml ./
 RUN poetry config virtualenvs.create false
 RUN poetry install --no-interaction
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #36 

**How to prepare for test**:
- [x] Remove any previous image present locally

### How to test:
- Run `docker-compose up` and make sure that the image is pushed to Docker Compose (stage): https://hub.docker.com/r/clinicalgenomics/preclinvar-stage/tags

### Expected outcome:
- [x] The tests above should be successful

### Review:
- [x] Tests executed by GitHub actions
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
