### PR TITLE
Patch 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [1.0.1]
+### Fixed
 - Fixed Dockerfile building error resulting in prod image release failed to be pushed to Docker Hub
 
 ## [1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## [unreleased]
-- Fixed Dockerfile building error resulting in prod image release failed to be pushed to Docker Hub 
+## [1.0.1]
+- Fixed Dockerfile building error resulting in prod image release failed to be pushed to Docker Hub
 
 ## [1.0]
 ### Added

--- a/preClinVar/__version__.py
+++ b/preClinVar/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "1.0"
+VERSION = "1.0.1"


### PR DESCRIPTION
## [unreleased]
### Fixed
- Fixed Dockerfile building error resulting in prod image release failed to be pushed to Docker Hub 

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
