### PR TITLE
Do not crash when empty CSV files are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Fixed
+- Prevent CSV file parsing StopIteration error when provided files are empty
+
 ## [1.0.1]
 ### Fixed
 - Fixed Dockerfile building error resulting in prod image release failed to be pushed to Docker Hub

--- a/preClinVar/csv_parser.py
+++ b/preClinVar/csv_parser.py
@@ -221,9 +221,8 @@ async def csv_lines(csv_file):
         with file_copy as f:
             f.write(contents)
 
-        with open(file_copy.name, "r", encoding="utf-8") as csvf:
+        with open(file_copy.name) as csvf:
             csvreader = DictReader(csvf)
-            next(csvreader)  # skip header
             for row in csvreader:
                 lines.append(row)
 
@@ -231,4 +230,4 @@ async def csv_lines(csv_file):
         file_copy.close()  # Close temp file
         os.unlink(file_copy.name)  # Delete temp file
 
-    return lines
+    return lines[1:] if lines else lines  # skip the header

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -100,7 +100,9 @@ async def csv_2_json(files: List[UploadFile] = File(...)):
     if not casedata_lines or not variants_lines:
         return JSONResponse(
             status_code=400,
-            content={"message": "Both 'Variant' and 'CaseData' csv files are required"},
+            content={
+                "message": "Both 'Variant' and 'CaseData' csv files are required and should not be empty"
+            },
         )
 
     # Convert lines extracted from csv files to a submission object (a dictionary)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,7 +38,10 @@ def test_csv_2_json_missing_file():
     response = client.post("/csv_2_json", files=files)
     # THEN the endpoint should return error
     assert response.status_code == 400
-    assert response.json()["message"] == "Both 'Variant' and 'CaseData' csv files are required"
+    assert (
+        response.json()["message"]
+        == "Both 'Variant' and 'CaseData' csv files are required and should not be empty"
+    )
 
 
 def test_csv_2_json_malformed_file():


### PR DESCRIPTION
### This PR adds | fixes:
- fix #42 

### How to test:
- Deploy the branch on cg-vm1 
- Test the csv_2_json endpoint with an empty file

### Expected outcome:
- [ ] The endpoint should not crash, but return a 400 error with the message:` Both 'Variant' and 'CaseData' csv files are required and should not be empty`

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
