### PR TITLE
Support for tab delimited CSV files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [unreleased]
 ### Added
-- Support for tab-delimited (`\t`) csv files
+- Support for tab-delimited (`\t`) files in csv_2_json endpoint
 ### Fixed
 - Do not crash when parsing Variant CSV files with no assertion criteria
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [unreleased]
+### Added
+- Support for tab-delimited (`\t`) csv files
 ### Fixed
 - Do not crash when parsing Variant CSV files with no assertion criteria
 

--- a/preClinVar/csv_parser.py
+++ b/preClinVar/csv_parser.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from csv import DictReader
+from csv import DictReader, Sniffer
 from tempfile import NamedTemporaryFile
 
 LOG = logging.getLogger("uvicorn.access")
@@ -215,6 +215,7 @@ async def csv_lines(csv_file):
     """
 
     contents = await csv_file.read()
+    dialect = Sniffer().sniff(contents.decode("utf-8"), [",", "\t"])
     file_copy = NamedTemporaryFile(delete=False)
     lines = []
     try:
@@ -222,7 +223,7 @@ async def csv_lines(csv_file):
             f.write(contents)
 
         with open(file_copy.name) as csvf:
-            csvreader = DictReader(csvf)
+            csvreader = DictReader(csvf, delimiter=dialect.delimiter)
             for row in csvreader:
                 lines.append(row)
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #48 

### How to test:
- Locally, feed tab separated files to the csv_2_json endpoint

### Expected outcome:
- [x] Main branch should return error 400: bad request
- [x] This brain should convert the files

### Review:
- [ ] Code approved by
- [x] Tests executed by CR, GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
