### PR TITLE
Prepare version 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [1.1]
 ### Added
 - Support for tab-delimited (`\t`) files in csv_2_json endpoint
 ### Fixed

--- a/preClinVar/__version__.py
+++ b/preClinVar/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.2"
+VERSION = "1.1"


### PR DESCRIPTION
## [1.1]
### Added
- Support for tab-delimited (`\t`) files in csv_2_json endpoint
### Fixed
- Do not crash when parsing Variant CSV files with no assertion criteria

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
