### PR TITLE
Simplify and fix CSV and TSV files parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Support for tab-delimited (`\t`) files in csv_2_json endpoint
 ### Fixed
 - Do not crash when parsing Variant CSV files with no assertion criteria
+- Simplify and fix CSV and TSV files parsing
 
 ## [1.0.2]
 ### Fixed

--- a/preClinVar/csv_parser.py
+++ b/preClinVar/csv_parser.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from csv import DictReader, Sniffer
+from csv import DictReader
 from tempfile import NamedTemporaryFile
 
 LOG = logging.getLogger("uvicorn.access")

--- a/preClinVar/csv_parser.py
+++ b/preClinVar/csv_parser.py
@@ -272,5 +272,4 @@ async def csv_lines(csv_file):
     else:
         lines = _csv_file_lines(contents)
 
-    LOG.error(lines)
     return lines

--- a/preClinVar/csv_parser.py
+++ b/preClinVar/csv_parser.py
@@ -213,17 +213,17 @@ async def csv_lines(csv_file):
     Returns:
         lines(list of dictionaries). Example [{'##Local ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Linking ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Gene symbol': 'XDH'}, ..]
     """
-
-    contents = await csv_file.read()
-    dialect = Sniffer().sniff(contents.decode("utf-8"), [",", "\t"])
-    file_copy = NamedTemporaryFile(delete=False)
     lines = []
+    file_copy = NamedTemporaryFile(delete=False)
     try:
+        contents = await csv_file.read()
+        contents = contents.replace(b"\t", b",").replace(b"\r", b"")
+
         with file_copy as f:
             f.write(contents)
 
         with open(file_copy.name) as csvf:
-            csvreader = DictReader(csvf, delimiter=dialect.delimiter)
+            csvreader = DictReader(csvf, delimiter=",")
             for row in csvreader:
                 lines.append(row)
 
@@ -231,4 +231,4 @@ async def csv_lines(csv_file):
         file_copy.close()  # Close temp file
         os.unlink(file_copy.name)  # Delete temp file
 
-    return lines[1:] if lines else lines  # skip the header
+    return lines

--- a/preClinVar/csv_parser.py
+++ b/preClinVar/csv_parser.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 import os
 from csv import DictReader
@@ -205,6 +206,58 @@ def csv_fields_to_submission(variants_lines, casedata_lines):
     return {"clinvarSubmission": items}
 
 
+def _tsv_file_lines(contents):
+    """Retrieve contents of a tab-separated file
+
+    Args:
+        contents(bytes): contents of one of the files uploaded, as bytes
+
+    Returns:
+        line_dicts(list): a list of dictionaries, one for each line of the original file
+    """
+    lines = []
+    try:
+        line_contents = contents.decode("UTF-8").replace("\r", "").split("\n")
+        header = line_contents[0].split("\t")
+        for row in line_contents[1:]:
+            if row.rstrip():
+                row_values = row.split("\t")
+                line = {}
+                for n, key in enumerate(header):
+                    line[key] = row_values[n]
+                lines.append(line)
+    except Exception as ex:
+        LOG.error("An error occurred while parsing TSV file")
+    return lines
+
+
+def _csv_file_lines(contents):
+    """Retrieve contents of a tab-separated file
+
+    Args:
+        contents(bytes): contents of one of the files uploaded, as bytes
+
+    Returns:
+        lines(list): a list of rows from a DictReader object
+    """
+    lines = []
+    file_copy = NamedTemporaryFile(delete=False)
+    try:
+        with file_copy as f:
+            f.write(contents)
+
+        with open(file_copy.name) as csvf:
+            csvreader = DictReader(csvf)
+            for row in csvreader:
+                lines.append(row)
+
+    finally:
+        file_copy.close()  # Close temp file
+        os.unlink(file_copy.name)  # Delete temp file
+
+    return lines
+
+
 async def csv_lines(csv_file):
     """Extracts lines from a csv file using a csv DictReader
 
@@ -213,22 +266,11 @@ async def csv_lines(csv_file):
     Returns:
         lines(list of dictionaries). Example [{'##Local ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Linking ID': '1d9ce6ebf2f82d913cfbe20c5085947b', 'Gene symbol': 'XDH'}, ..]
     """
-    lines = []
-    file_copy = NamedTemporaryFile(delete=False)
-    try:
-        contents = await csv_file.read()
-        contents = contents.replace(b"\t", b",").replace(b"\r", b"")
+    contents = await csv_file.read()
+    if b"\t" in contents:
+        lines = _tsv_file_lines(contents)
+    else:
+        lines = _csv_file_lines(contents)
 
-        with file_copy as f:
-            f.write(contents)
-
-        with open(file_copy.name) as csvf:
-            csvreader = DictReader(csvf, delimiter=",")
-            for row in csvreader:
-                lines.append(row)
-
-    finally:
-        file_copy.close()  # Close temp file
-        os.unlink(file_copy.name)  # Delete temp file
-
+    LOG.error(lines)
     return lines

--- a/preClinVar/csv_parser.py
+++ b/preClinVar/csv_parser.py
@@ -224,7 +224,7 @@ def _tsv_file_lines(contents):
                 row_values = row.split("\t")
                 line = {}
                 for n, key in enumerate(header):
-                    line[key] = row_values[n]
+                    line[key.strip('"')] = row_values[n].strip('"')
                 lines.append(line)
     except Exception as ex:
         LOG.error("An error occurred while parsing TSV file")
@@ -272,4 +272,5 @@ async def csv_lines(csv_file):
     else:
         lines = _csv_file_lines(contents)
 
+    LOG.error(lines)
     return lines

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from typing import List
 
 import requests
@@ -91,9 +92,15 @@ async def csv_2_json(files: List[UploadFile] = File(...)):
 
     for file in files:
         file_lines = await csv_lines(file)
-        if "CaseData" in file.filename:
+        if not file_lines:
+            return JSONResponse(
+                status_code=400,
+                content={"message": f"Malformed file {file.filename}"},
+            )
+
+        if re.search("CaseData", file.filename, re.IGNORECASE):
             casedata_lines = file_lines
-        elif "Variant" in file.filename:
+        elif re.search("Variant", file.filename, re.IGNORECASE):
             variants_lines = file_lines
 
     # Make sure both files were provided in request

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -105,6 +105,7 @@ def test_csv_2_json_tab_separated():
         ]
 
         response = client.post("/csv_2_json", files=files)
+        # assert response.json() == "meh"
         assert response.status_code == 200
 
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix an error in current main branch causing the files to be parsed wrongly

### How to test: Use the swagger http://127.0.0.1:8000/docs#/default/csv_2_json_csv_2_json_post
- Convert CSV files to json submission
- Convert TSV files to json submission

### Expected outcome:
- [ ] Both tests should pass

### Review:
- [ ] Code approved by
- [ ] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
