### PR TITLE
Add 5 useful GitHub actions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,20 @@
+name: Black check
+
+on: [pull_request]
+
+jobs:
+  black-check:
+    runs-on: ubuntu-latest
+    name: Black
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@master
+        with:
+          python-version: 3.8
+      - name: install black
+        run: |
+          pip install black==22.3.0
+      - name: run black
+        run: |
+          black . --check --line-length 100

--- a/.github/workflows/keep_changelog.yml
+++ b/.github/workflows/keep_changelog.yml
@@ -1,0 +1,15 @@
+name: "Changelog Reminder"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: dangoslen/changelog-enforcer@v1.1.1
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabel: 'Skip-Changelog'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: flake8 Lint
+
+on: [pull_request]
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-latest
+    name: Flake8
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@master
+        with:
+          python-version: 3.8
+      - name: install flake8
+        run: |
+          pip install flake8
+      - name: run flake8
+        run: |
+          flake8 . --max-line-length=100
+        continue-on-error: true

--- a/.github/workflows/vulture.yml
+++ b/.github/workflows/vulture.yml
@@ -1,0 +1,25 @@
+
+
+name: "Vulture - Find unused code"
+on:
+  - pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: vulture
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Find changed Python files
+        id: files
+        uses: Ana06/get-changed-files@v2.0.0
+        with:
+          filter: "*.py"
+
+      - name: Scavenge
+        uses: anaynayak/python-vulture-action@v1.0
+        id: vulture
+        with:
+          vulture-args: --min-confidence 80 ${{steps.files.outputs.all}}
+        continue-on-error: true

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,15 @@
+name: woke
+on:
+  - pull_request
+jobs:
+  woke:
+    name: Non-inclusive language check with woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [unreleased]
 ### Added
 - A new tsv_2_json endpoint to convert TSV files in json submission objects
+- "Keep a Changelog" GitHub action
 ### Changed
 - New API schema introduced on 2022-11-21
 - Modified file parsing code to create submission jsons compliant with the new API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## [unreleased]
 ### Added
 - A new tsv_2_json endpoint to convert TSV files in json submission objects
-- "Keep a Changelog" GitHub action
+- `Keep a Changelog` GitHub action
+- `Black` GitHub action
+- `Flake8 Lint` GitHub action
+- `Vulture` GitHub action
+- `Woke` GitHub action
 ### Changed
 - New API schema introduced on 2022-11-21
 - Modified file parsing code to create submission jsons compliant with the new API

--- a/preClinVar/resources/__init__.py
+++ b/preClinVar/resources/__init__.py
@@ -5,4 +5,6 @@ import pkg_resources
 subm_schema = "submission_schema.json"
 
 ###### Path to submission schema file ######
-subm_schema_path = pkg_resources.resource_filename("preClinVar", "/".join(["resources", subm_schema]))
+subm_schema_path = pkg_resources.resource_filename(
+    "preClinVar", "/".join(["resources", subm_schema])
+)


### PR DESCRIPTION
### This PR adds | fixes:
- fix #53

Adds:

- `Keep a Changelog` GitHub action
- `Black` GitHub action
- `Flake8 Lint` GitHub action
- `Vulture` GitHub action
- `Woke` GitHub action

### How to test:
- Check if GitHub actions pass

### Review:
- [ ] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
