### PR TITLE
Add Actions badges on Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `Flake8 Lint` GitHub action
 - `Vulture` GitHub action
 - `Woke` GitHub action
+- Badges showing the status of GitHub actions on README page
 ### Changed
 - New API schema introduced on 2022-11-21
 - Modified file parsing code to create submission jsons compliant with the new API

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # PreClinVar
 A ClinVar API submission helper written in FastAPI.
 
-[![codecov](https://codecov.io/gh/Clinical-Genomics/preClinVar/branch/main/graph/badge.svg?token=ZE8LP4R3ZJ)](https://codecov.io/gh/Clinical-Genomics/preClinVar)
+[![Coverage Status][codecov-img]][codecov-url]
+![GitHub Release Date][github-release-date]
+[![Woke][woke-image]][woke-url]
 
 ## Available endpoints:
 
@@ -62,3 +64,10 @@ The server will run on localhost and default port 8000 (http://127.0.0.1:8000)
 
 The endpoints will be available under the docs: http://127.0.0.1:8000/docs (http://127.0.0.1:7000/docs if you are running the dockerized version of the app).
 They can be tested with files provided in this repository, in the demo folder: https://github.com/Clinical-Genomics/preClinVar/tree/main/preClinVar/demo
+
+
+[codecov-img]: https://codecov.io/gh/Clinical-Genomics/preClinVar/branch/main/graph/badge.svg?token=ZE8LP4R3ZJ
+[codecov-url]: https://codecov.io/gh/Clinical-Genomics/preClinVar
+[github-release-date]: https://img.shields.io/github/release-date/Clinical-Genomics/preClinVar
+[woke-image]: https://github.com/Clinical-Genomics/preClinVar/actions/workflows/woke.yml/badge.svg
+[woke-url]: https://github.com/Clinical-Genomics/preClinVar/actions/workflows/woke.yml


### PR DESCRIPTION
### This PR adds | fixes:
- Add 2 badges (Woke and Released) on README page

<img width="442" alt="image" src="https://user-images.githubusercontent.com/28093618/204214976-6612d723-b238-4576-b259-951fbb901ebe.png">

### How to test:
- See README preview and check that badge links work

### Expected outcome:
- [x] Badges look good and links work

### Review:
- [ ] Code approved by
- [ ] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
