### PR TITLE
Fixed parsing of HP/HPO  and HGVS fields 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Fixed
+- Parsing of `Condition ID type`
+
 ## [2.0]
 ### Added
 - A new tsv_2_json endpoint to convert TSV files in json submission objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [unreleased]
 ### Fixed
 - Parsing of `Condition ID type`
+- Do not include HGVS field in submission if it is null
 
 ## [2.0]
 ### Added

--- a/preClinVar/constants.py
+++ b/preClinVar/constants.py
@@ -1,2 +1,11 @@
 DRY_RUN_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true"
 VALIDATE_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/apitest/v1/submissions"
+
+CONDITIONS_MAP = {
+    "HPO": "HP",
+    "MedGen": "MedGen",
+    "MeSH": "MeSH",
+    "MONDO": "MONDO",
+    "OMIM": "OMIM",
+    "Orphanet": "Orphanet",
+}

--- a/preClinVar/file_parser.py
+++ b/preClinVar/file_parser.py
@@ -159,7 +159,9 @@ def set_item_variant_set(item, variant_dict):
     # According the schema: The interpreted variant must be described either by HGVS or by chromosome coordinates, but not both.
     # Our cvs files contain HGVS so we parse only these at the moment
     item["variantSet"] = {}
-    variant = {"hgvs": variant_dict.get("HGVS")}
+    variant = {}
+    if variant_dict.get("HGVS"):
+        variant["hgvs"] = variant_dict["HGVS"]
 
     genes = variant_dict.get("Gene symbol")
     if genes:

--- a/preClinVar/file_parser.py
+++ b/preClinVar/file_parser.py
@@ -4,6 +4,8 @@ import os
 from csv import DictReader
 from tempfile import NamedTemporaryFile
 
+from preClinVar.constants import CONDITIONS_MAP
+
 LOG = logging.getLogger("uvicorn.access")
 
 
@@ -70,7 +72,7 @@ def set_item_condition_set(item, variant_dict):
     conditions = []
 
     # Check if phenotype was specified in Variant file
-    cond_dbs = variant_dict.get("Condition ID type")
+    cond_dbs = CONDITIONS_MAP.get(variant_dict.get("Condition ID type"))
     cond_values = variant_dict.get("Condition ID value")
 
     if cond_dbs and cond_values:

--- a/preClinVar/file_parser.py
+++ b/preClinVar/file_parser.py
@@ -1,4 +1,3 @@
-import csv
 import logging
 import os
 from csv import DictReader


### PR DESCRIPTION
### This PR adds | fixes:
`Condition ID type` has HPO named as HPO [ref](https://github.com/Clinical-Genomics/scout/issues/3689#issuecomment-1330553160) but the key is named `HP` in the API [ref](https://github.com/Clinical-Genomics/preClinVar/blob/04cee1f7ae15563346d6753ccf7c6ab214bcdd9e/preClinVar/resources/submission_schema.json#L912)

### How to test:
- Parse a submission file that contains HPO terms and make sure it is parsed correctly

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
