### PR TITLE
Fixed muliple pheno parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ### Added
 - Parsing of `variantType`, `referenceCopyNumber`, `copyNumber` and `chromosomeCoordinates` fields from CSV/TSV files
 - Genome assembly can be passed as an optional param to tsv_2_json and csv_to_json to create submission containing chromosome coordinates
+### Fixed
+- Parsing of multiple condition IDs from csv/tsv files
 
 ## [2.0.1]
 ### Fixed

--- a/preClinVar/file_parser.py
+++ b/preClinVar/file_parser.py
@@ -71,14 +71,13 @@ def set_item_condition_set(item, variant_dict):
     conditions = []
 
     # Check if phenotype was specified in Variant file
-    cond_dbs = CONDITIONS_MAP.get(variant_dict.get("Condition ID type"))
+    cond_db = CONDITIONS_MAP.get(variant_dict.get("Condition ID type"))
     cond_values = variant_dict.get("Condition ID value")
 
-    if cond_dbs and cond_values:
-        cond_dbs = cond_dbs.split(";")
+    if cond_db and cond_values:
         cond_values = cond_values.split(";")
-        for cond_n, cond_db in enumerate(cond_dbs):
-            conditions.append({"db": cond_db, "id": cond_values[cond_n]})
+        for cond_id in cond_values:
+            conditions.append({"db": cond_db, "id": cond_id})
     if conditions:
         item["conditionSet"] = {"condition": conditions}
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #69 

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
- Try converting a Variant file containing more than one phenotype (OMIM or HPO)

### Expected outcome:
- [x] Json submission should contain multiple phenotypes, not just one as it is now

### Review:
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
