### PR TITLE
Replace stage URL with prod URL on README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Changed
+- Provide the URL to the prod service running on the Clinical Genomics server instead of the stage one on README page
+
 ## [2.1]
 ### Added
 - Parsing of `variantType`, `referenceCopyNumber`, `copyNumber` and `chromosomeCoordinates` fields from CSV/TSV files

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A ClinVar API submission helper written in FastAPI.
 
 ## Availability:
 
-A running demo instance of the service is available at https://preclinvar-stage.scilifelab.se/docs
+A running instance of the service is available at https://preclinvar.scilifelab.se/docs
 
 ## Available endpoints:
 


### PR DESCRIPTION
### This PR adds | fixes:
- Replace stage URL with prod URL on README page

### How to test:
- NO tests needed, it's docs

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
