### PR TITLE
Prepare version 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [2.2]
 ### Changed
 - Provide the URL to the prod service running on the Clinical Genomics server instead of the stage one on README page
 ### Fixed

--- a/preClinVar/__version__.py
+++ b/preClinVar/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "2.1"
+VERSION = "2.2"


### PR DESCRIPTION
## [2.2]
### Changed
- Provide the URL to the prod service running on the Clinical Genomics server instead of the stage one on README page
### Fixed
- Do not parse dbSNP IDs as `Accession` key/values

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
