### PR TITLE
Prepare minor version 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [2.3]
 ### Changed
 - Fix uppercase/lowercase letters when parsing clinsig terms from files
 

--- a/preClinVar/__version__.py
+++ b/preClinVar/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "2.2"
+VERSION = "2.3"


### PR DESCRIPTION
## [2.3]
### Changed
- Fix uppercase/lowercase letters when parsing clinsig terms from files

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
