### PR TITLE
Combine `Reference sequence` and `HGVS` fields from Variant file to create the hgvs field in json submission object 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Fixed
+- Combine `Reference sequence` and `HGVS` fields from Variant file to create the hgvs field in json submission object 
+
 ## [2.3]
 ### Changed
 - Fix uppercase/lowercase letters when parsing clinsig terms from files

--- a/preClinVar/file_parser.py
+++ b/preClinVar/file_parser.py
@@ -228,9 +228,10 @@ def set_item_variant_set(item, variant_dict):
     genes = variant_dict.get("Gene symbol")
     if genes:
         variant["gene"] = [{"symbol": symbol} for symbol in genes.split(";")]
+    refseq = variant_dict.get("Reference sequence")
     hgvs = variant_dict.get("HGVS")
-    if hgvs:  # A Variant should have wither HGVS (hgvs in schema)
-        variant["hgvs"] = hgvs
+    if hgvs and refseq:  # A Variant should have wither HGVS (hgvs in schema)
+        variant["hgvs"] = ":".join([refseq, hgvs])
     else:  # OR chromosome coordinates (chromosomeCoordinates in schema)
         variant["chromosomeCoordinates"] = _set_chrom_coordinates(variant_dict)
 

--- a/preClinVar/file_parser.py
+++ b/preClinVar/file_parser.py
@@ -230,7 +230,7 @@ def set_item_variant_set(item, variant_dict):
         variant["gene"] = [{"symbol": symbol} for symbol in genes.split(";")]
     refseq = variant_dict.get("Reference sequence")
     hgvs = variant_dict.get("HGVS")
-    if hgvs and refseq:  # A Variant should have wither HGVS (hgvs in schema)
+    if hgvs and refseq:  # A Variant should have either HGVS (hgvs in schema)
         variant["hgvs"] = ":".join([refseq, hgvs])
     else:  # OR chromosome coordinates (chromosomeCoordinates in schema)
         variant["chromosomeCoordinates"] = _set_chrom_coordinates(variant_dict)

--- a/tests/test_file_parser.py
+++ b/tests/test_file_parser.py
@@ -1,5 +1,5 @@
 from preClinVar.constants import CLNSIG_TERMS
-from preClinVar.file_parser import set_item_clin_sig
+from preClinVar.file_parser import set_item_clin_sig, set_item_variant_set
 
 
 def test_set_item_clin_sig_fix_case():
@@ -13,3 +13,16 @@ def test_set_item_clin_sig_fix_case():
 
     # THEN it's converted into a compliant term
     assert item["clinicalSignificance"]["clinicalSignificanceDescription"] in CLNSIG_TERMS
+
+
+def test_set_item_variant_set_hgvs():
+    """Test the function that sets variantSet keys/values for a variant item in the submission object"""
+    item = {}
+    REFSEQ = "NM_015450.3"
+    HGVS = "c.903G>T"
+    variant_dict = {"Reference sequence": REFSEQ, "HGVS": HGVS}
+
+    # WHEN variant set is created from variant_dict
+    set_item_variant_set(item, variant_dict)
+    # THEN hgvs field should contain both Reference sequence and HGVS
+    assert item["variantSet"]["variant"][0]["hgvs"] == ":".join([REFSEQ, HGVS])


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #82 

**How to prepare for test**:
- launch it locally

### How to test:
- convert the 2 demo files in a submission objecct

### Expected outcome:
- [x] Submission object should contain a complecte hgvs (refseq:hgvs)

### Review:
- [x] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
