### PR TITLE
Create patch version 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [unreleased]
+## [2.3.1]
 ### Fixed
-- Combine `Reference sequence` and `HGVS` fields from Variant file to create the hgvs field in json submission object 
+- Combine `Reference sequence` and `HGVS` fields from Variant file to create the hgvs field in json submission object
 
 ## [2.3]
 ### Changed

--- a/preClinVar/__version__.py
+++ b/preClinVar/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "2.3"
+VERSION = "2.3.1"


### PR DESCRIPTION
## [2.3.1]
### Fixed
- Combine `Reference sequence` and `HGVS` fields from Variant file to create the hgvs field in json submission object

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
