### PR TITLE
Fix description of response returned by dry run in README file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Updated version of external images in GitHub actions
 ### Fixed
 - Bump certifi from 2022.12.7 to 2023.7.22
+- Description of the response returned by dry run endpoint in README file 
 
 ## [2.3.1]
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Transforms csv submission files (Variant.csv and CaseData.csv) into a json submi
 
 ### dry_run
 
-Proxy endpoint to the ClinVar submissions API (dry-run): https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true. Requires a valid API key and a json file containing a submission object. If the request is valid (and the json submission object is validated) returns a submission ID which can be used for a real submission.
+Proxy endpoint to the ClinVar submissions API (dry-run): https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true. Requires a valid API key and a json file containing a submission object. If the request is valid (and the json submission object is validated) returns a response with code 200 and json body with the message value "success".
 
 ### validate
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix  #86 - Dry run does not return any new SUBmission ID, but success message

<img width="470" alt="image" src="https://github.com/Clinical-Genomics/preClinVar/assets/28093618/0e7a4981-3766-4d77-b547-5d6b80adb5c4">


### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
