### PR TITLE
Minor release 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [2.4]
 ### Changed
 - Updated version of external images in GitHub actions
 - Updated API submission schema to the latest
@@ -9,6 +9,7 @@
 - Bump certifi from 2022.12.7 to 2023.7.22
 - Description of the response returned by dry run endpoint in README file
 - Migrate from deprecated `pkg_resources` lib to `importlib_resources`
+- Updated python-multipart from 0.0.5 to 0.0.7 to address security alert by dependabot
 
 ## [2.3.1]
 ### Fixed


### PR DESCRIPTION
## [2.4]
### Changed
- Updated version of external images in GitHub actions
- Updated API submission schema to the latest
- Demo variant to take care of "Somatic mutation" no longer available among Mode of inheritance choices
- `clinicalSignificance.clinicalSignificanceDescription` value extracted from `Clinical significance` or `Germline classification` column
- `clinicalSignificance.comment` values extracted from `Comment on clinical significance` or `Comment on classification` column
### Fixed
- Bump certifi from 2022.12.7 to 2023.7.22
- Description of the response returned by dry run endpoint in README file
- Migrate from deprecated `pkg_resources` lib to `importlib_resources`
- Updated python-multipart from 0.0.5 to 0.0.7 to address security alert by dependabot

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
