### PR TITLE
Expand validate output to display link for downloading json with submission errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Changed 
+- Expand the output of validate endpoint to return the link for downloading json file containing evantual submission errors
+
 ## [2.5.2]
 ### Fixed
 - Upload to Codecov step in `tests_n_coverage.yml` action

--- a/preClinVar/constants.py
+++ b/preClinVar/constants.py
@@ -1,6 +1,7 @@
 DRY_RUN_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true"
 VALIDATE_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/apitest/v1/submissions"
 
+
 CLNSIG_TERMS = [
     "Pathogenic",
     "Likely pathogenic",

--- a/preClinVar/constants.py
+++ b/preClinVar/constants.py
@@ -1,7 +1,6 @@
 DRY_RUN_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true"
 VALIDATE_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/apitest/v1/submissions"
 
-
 CLNSIG_TERMS = [
     "Pathogenic",
     "Likely pathogenic",

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -35,7 +35,7 @@ async def root():
 
 @app.post("/validate")
 async def validate(api_key: str = Form(), json_file: UploadFile = File(...)) -> JSONResponse:
-    """A proxy to the apitest submission ClinVar API endpoint"""
+    """A proxy to the apitest submission ClinVar API endpoint. Returns the ID of the submission and the data summary report with eventual errors."""
     # Create a submission header
     header = build_header(api_key)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -315,19 +315,53 @@ def test_validate_wrong_api_key():
 def test_validate():
     """Test the validated API proxy endpoint (with a mocked ClinVar API response)"""
 
-    # GIVEN a json submission file
-    json_file = {"json_file": open(subm_json_path, "rb")}
-
-    # AND a mocked ClinVar API
+    # GIVEN a mocked POST response from CLinVar apitest endpoint
     responses.add(
         responses.POST,
         VALIDATE_SUBMISSION_URL,
         json={"id": DEMO_SUBMISSION_ID},
-        status=201,  # The ClinVar API returs code 201 when request is successful (created)
+        status=201,  # The ClinVar API returns code 201 when request is successful (created)
     )
+
+    # GIVEN a mocked error response from apitest actions endpoint
+    actions: list[dict] = [
+        {
+            "id": "SUB14404390-1",
+            "targetDb": "clinvar-test",
+            "status": "error",
+            "updated": "2024-04-26T06:41:04.533900Z",
+            "responses": [
+                {
+                    "status": "error",
+                    "message": {
+                        "severity": "error",
+                        "errorCode": "2",
+                        "text": 'Your ClinVar submission processing status is "Error". Please find the details in the file referenced by actions[0].responses[0].files[0].url.',
+                    },
+                    "files": [
+                        {
+                            "url": "https://submit.ncbi.nlm.nih.gov/api/2.0/files/vxgc6vtt/sub14404390-summary-report.json/?format=attachment"
+                        }
+                    ],
+                    "objects": [],
+                }
+            ],
+        }
+    ]
+
+    responses.add(
+        responses.GET,
+        f"{VALIDATE_SUBMISSION_URL}/{DEMO_SUBMISSION_ID}/actions/",
+        json={"actions": actions},
+        status=200,  # The ClinVar API returns code 201 when request is successful (created)
+    )
+
+    # GIVEN a json submission file
+    json_file = {"json_file": open(subm_json_path, "rb")}
 
     response = client.post("/validate", data={"api_key": DEMO_API_KEY}, files=json_file)
 
-    # THEN the ClinVar API proxy should return "success"
-    assert response.status_code == 201  # Created
-    assert response.json()["id"] == DEMO_SUBMISSION_ID
+    # THEN the ClinVar API proxy should return the expected data
+    assert response.status_code == 200
+    assert response.json()["actions"][0]["id"]
+    assert response.json()["actions"][0]["responses"][0]["files"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -312,7 +312,7 @@ def test_validate_wrong_api_key():
 
 
 @responses.activate
-def test_validate():
+def test_validate_error():
     """Test the validated API proxy endpoint (with a mocked ClinVar API response)"""
 
     # GIVEN a mocked POST response from CLinVar apitest endpoint


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #120

@dnil FIY

### How to test:
- Use validate endpoint with a submission that you know contains errors

### Expected outcome:
- [x] The json data returned from ClinVar should return a link to download the file with the submission data analysis

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
