### PR TITLE
Revert Validate and add another endpoint to check the validation errors of a demo submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [unreleased]
-### Changed 
-- Expand the output of validate endpoint to return the link for downloading json file containing evantual submission errors
+### Added 
+- An endpoint `/apitest-status` that returns a response containing a link to the eventual json file with the submissions data errors
 
 ## [2.5.2]
 ### Fixed

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -33,16 +33,32 @@ async def root():
     return {"message": f"preClinVar v{VERSION} is up and running!"}
 
 
+@app.post("/apitest-status")
+async def apitest_status(api_key: str = Form(), submission_id: str = Form()) -> JSONResponse:
+    """Returns the status (validation) of a test submission to the apitest endpoint."""
+
+    # Create a submission header
+    header = build_header(api_key)
+
+    apitest_actions_url = f"{VALIDATE_SUBMISSION_URL}/{submission_id}/actions/"
+    apitest_actions_resp = requests.get(apitest_actions_url, headers=header)
+
+    return JSONResponse(
+        status_code=apitest_actions_resp.status_code,
+        content=apitest_actions_resp.json(),
+    )
+
+
 @app.post("/validate")
-async def validate(api_key: str = Form(), json_file: UploadFile = File(...)) -> JSONResponse:
-    """A proxy to the apitest submission ClinVar API endpoint. Returns the ID of the submission and the data summary report with eventual errors."""
+async def validate(api_key: str = Form(), json_file: UploadFile = File(...)):
+    """A proxy to the apitest ClinVar API endpoint"""
     # Create a submission header
     header = build_header(api_key)
 
     # Get json file content as dict:
     submission_obj = json.load(json_file.file)
 
-    # And use it as data in a POST request to API
+    # And use it in POST request to API
     data = {
         "actions": [
             {
@@ -52,23 +68,10 @@ async def validate(api_key: str = Form(), json_file: UploadFile = File(...)) -> 
             }
         ]
     }
-    apitest_resp = requests.post(VALIDATE_SUBMISSION_URL, data=json.dumps(data), headers=header)
-    apitest_json: dict = apitest_resp.json()
-
-    # If submission was created, return eventual link for downloading json file with data-specific errors
-    if apitest_resp.status_code == 201:
-
-        apitest_actions_url = f"{VALIDATE_SUBMISSION_URL}/{apitest_json.get('id')}/actions/"
-        apitest_actions_resp = requests.get(apitest_actions_url, headers=header)
-
-        return JSONResponse(
-            status_code=apitest_actions_resp.status_code,
-            content=apitest_actions_resp.json(),
-        )
-
+    resp = requests.post(VALIDATE_SUBMISSION_URL, data=json.dumps(data), headers=header)
     return JSONResponse(
-        status_code=apitest_resp.status_code,
-        content=apitest_json,
+        status_code=resp.status_code,
+        content=resp.json(),
     )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -332,49 +332,50 @@ def test_validate():
     assert response.status_code == 201  # Created
     assert response.json()["id"] == DEMO_SUBMISSION_ID
 
-    @responses.activate
-    def test_apitest_status():
-        """Test the endpoint that sends GET requests to the apitest actions ClinVar endpoint."""
 
-        # GIVEN a mocked error response from apitest actions endpoint
-        actions: list[dict] = [
-            {
-                "id": "SUB14404390-1",
-                "targetDb": "clinvar-test",
-                "status": "error",
-                "updated": "2024-04-26T06:41:04.533900Z",
-                "responses": [
-                    {
-                        "status": "error",
-                        "message": {
-                            "severity": "error",
-                            "errorCode": "2",
-                            "text": 'Your ClinVar submission processing status is "Error". Please find the details in the file referenced by actions[0].responses[0].files[0].url.',
-                        },
-                        "files": [
-                            {
-                                "url": "https://submit.ncbi.nlm.nih.gov/api/2.0/files/vxgc6vtt/sub14404390-summary-report.json/?format=attachment"
-                            }
-                        ],
-                        "objects": [],
-                    }
-                ],
-            }
-        ]
+@responses.activate
+def test_apitest_status():
+    """Test the endpoint that sends GET requests to the apitest actions ClinVar endpoint."""
 
-        responses.add(
-            responses.GET,
-            f"{VALIDATE_SUBMISSION_URL}/{DEMO_SUBMISSION_ID}/actions/",
-            json={"actions": actions},
-            status=200,  # The ClinVar API returns code 201 when request is successful (created)
-        )
+    # GIVEN a mocked error response from apitest actions endpoint
+    actions: list[dict] = [
+        {
+            "id": "SUB14404390-1",
+            "targetDb": "clinvar-test",
+            "status": "error",
+            "updated": "2024-04-26T06:41:04.533900Z",
+            "responses": [
+                {
+                    "status": "error",
+                    "message": {
+                        "severity": "error",
+                        "errorCode": "2",
+                        "text": 'Your ClinVar submission processing status is "Error". Please find the details in the file referenced by actions[0].responses[0].files[0].url.',
+                    },
+                    "files": [
+                        {
+                            "url": "https://submit.ncbi.nlm.nih.gov/api/2.0/files/vxgc6vtt/sub14404390-summary-report.json/?format=attachment"
+                        }
+                    ],
+                    "objects": [],
+                }
+            ],
+        }
+    ]
 
-        # GIVEN a call to the apitest_status endpoint
-        response = client.post(
-            "/validate", data={"api_key": DEMO_API_KEY, "submission_id": DEMO_SUBMISSION_ID}
-        )
+    responses.add(
+        responses.GET,
+        f"{VALIDATE_SUBMISSION_URL}/{DEMO_SUBMISSION_ID}/actions/",
+        json={"actions": actions},
+        status=200,  # The ClinVar API returns code 201 when request is successful (created)
+    )
 
-        # THEN the response should contain the provided actions
-        assert response.status_code == 200
-        assert response.json()["actions"][0]["id"]
-        assert response.json()["actions"][0]["responses"][0]["files"]
+    # GIVEN a call to the apitest_status endpoint
+    response = client.post(
+        "/apitest-status", data={"api_key": DEMO_API_KEY, "submission_id": DEMO_SUBMISSION_ID}
+    )
+
+    # THEN the response should contain the provided actions
+    assert response.status_code == 200
+    assert response.json()["actions"][0]["id"]
+    assert response.json()["actions"][0]["responses"][0]["files"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -312,56 +312,69 @@ def test_validate_wrong_api_key():
 
 
 @responses.activate
-def test_validate_error():
-    """Test the validated API proxy endpoint (with a mocked ClinVar API response)"""
-
-    # GIVEN a mocked POST response from CLinVar apitest endpoint
-    responses.add(
-        responses.POST,
-        VALIDATE_SUBMISSION_URL,
-        json={"id": DEMO_SUBMISSION_ID},
-        status=201,  # The ClinVar API returns code 201 when request is successful (created)
-    )
-
-    # GIVEN a mocked error response from apitest actions endpoint
-    actions: list[dict] = [
-        {
-            "id": "SUB14404390-1",
-            "targetDb": "clinvar-test",
-            "status": "error",
-            "updated": "2024-04-26T06:41:04.533900Z",
-            "responses": [
-                {
-                    "status": "error",
-                    "message": {
-                        "severity": "error",
-                        "errorCode": "2",
-                        "text": 'Your ClinVar submission processing status is "Error". Please find the details in the file referenced by actions[0].responses[0].files[0].url.',
-                    },
-                    "files": [
-                        {
-                            "url": "https://submit.ncbi.nlm.nih.gov/api/2.0/files/vxgc6vtt/sub14404390-summary-report.json/?format=attachment"
-                        }
-                    ],
-                    "objects": [],
-                }
-            ],
-        }
-    ]
-
-    responses.add(
-        responses.GET,
-        f"{VALIDATE_SUBMISSION_URL}/{DEMO_SUBMISSION_ID}/actions/",
-        json={"actions": actions},
-        status=200,  # The ClinVar API returns code 201 when request is successful (created)
-    )
+def test_validate():
+    """Test the endpoint validate, a proxy to ClinVar apitest, with a mocked ClinVar API response."""
 
     # GIVEN a json submission file
     json_file = {"json_file": open(subm_json_path, "rb")}
 
+    # AND a mocked ClinVar API
+    responses.add(
+        responses.POST,
+        VALIDATE_SUBMISSION_URL,
+        json={"id": DEMO_SUBMISSION_ID},
+        status=201,  # The ClinVar API returs code 201 when request is successful (created)
+    )
+
     response = client.post("/validate", data={"api_key": DEMO_API_KEY}, files=json_file)
 
-    # THEN the ClinVar API proxy should return the expected data
-    assert response.status_code == 200
-    assert response.json()["actions"][0]["id"]
-    assert response.json()["actions"][0]["responses"][0]["files"]
+    # THEN the ClinVar API proxy should return "success"
+    assert response.status_code == 201  # Created
+    assert response.json()["id"] == DEMO_SUBMISSION_ID
+
+    @responses.activate
+    def test_apitest_status():
+        """Test the endpoint that sends GET requests to the apitest actions ClinVar endpoint."""
+
+        # GIVEN a mocked error response from apitest actions endpoint
+        actions: list[dict] = [
+            {
+                "id": "SUB14404390-1",
+                "targetDb": "clinvar-test",
+                "status": "error",
+                "updated": "2024-04-26T06:41:04.533900Z",
+                "responses": [
+                    {
+                        "status": "error",
+                        "message": {
+                            "severity": "error",
+                            "errorCode": "2",
+                            "text": 'Your ClinVar submission processing status is "Error". Please find the details in the file referenced by actions[0].responses[0].files[0].url.',
+                        },
+                        "files": [
+                            {
+                                "url": "https://submit.ncbi.nlm.nih.gov/api/2.0/files/vxgc6vtt/sub14404390-summary-report.json/?format=attachment"
+                            }
+                        ],
+                        "objects": [],
+                    }
+                ],
+            }
+        ]
+
+        responses.add(
+            responses.GET,
+            f"{VALIDATE_SUBMISSION_URL}/{DEMO_SUBMISSION_ID}/actions/",
+            json={"actions": actions},
+            status=200,  # The ClinVar API returns code 201 when request is successful (created)
+        )
+
+        # GIVEN a call to the apitest_status endpoint
+        response = client.post(
+            "/validate", data={"api_key": DEMO_API_KEY, "submission_id": DEMO_SUBMISSION_ID}
+        )
+
+        # THEN the response should contain the provided actions
+        assert response.status_code == 200
+        assert response.json()["actions"][0]["id"]
+        assert response.json()["actions"][0]["responses"][0]["files"]


### PR DESCRIPTION
### This PR adds | fixes:
- Add an endpoint `/apitest-status` that returns a response containing a link to the eventual json file with the submissions data errors

### How to test:
- [x] Try the /apitest-status endpoint with the api key and the id of a submission already posted to the ClinVar apitest

### Expected outcome:
- [x] The response should visualize the actions with eventual errors

### Review:
- [ ] Code approved by
- [x] Tests executed by CR, GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
