### PR TITLE
Add an endpoint proxy to the submissions status of ClinVar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [unreleased]
 ### Added 
-- An endpoint `/apitest-status` that returns a response containing a link to the eventual json file with the submissions data errors
+- An endpoint `/apitest-status` that returns a response containing the status of a test submission, with link to the eventual json file with the submissions data errors
+- An endpoint `/status` that returns a response containing the status of a submission (submitted, processing, processed, error), with eventual error details
 ### Changed
 - Renamed `/validate` endpoint to `/apitest`
 

--- a/preClinVar/constants.py
+++ b/preClinVar/constants.py
@@ -1,4 +1,5 @@
-DRY_RUN_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true"
+SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions"
+DRY_RUN_SUBMISSION_URL = f"{SUBMISSION_URL}/?dry-run=true"
 VALIDATE_SUBMISSION_URL = "https://submit.ncbi.nlm.nih.gov/apitest/v1/submissions"
 
 CLNSIG_TERMS = [

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 
 from preClinVar.__version__ import VERSION
 from preClinVar.build import build_header, build_submission
-from preClinVar.constants import DRY_RUN_SUBMISSION_URL, VALIDATE_SUBMISSION_URL
+from preClinVar.constants import DRY_RUN_SUBMISSION_URL, SUBMISSION_URL, VALIDATE_SUBMISSION_URL
 from preClinVar.file_parser import csv_lines, file_fields_to_submission, tsv_lines
 from preClinVar.validate import validate_submission
 
@@ -216,4 +216,20 @@ async def csv_2_json(
     return JSONResponse(
         status_code=400,
         content={"message": f"Created json file contains validation errors: {valid_results[1]}"},
+    )
+
+
+@app.post("/status")
+async def status(api_key: str = Form(), submission_id: str = Form()) -> JSONResponse:
+    """Returns the status (validation) of a submission."""
+
+    # Create a submission header
+    header = build_header(api_key)
+
+    actions_url = f"{SUBMISSION_URL}/{submission_id}/actions/"
+    actions_resp = requests.get(actions_url, headers=header)
+
+    return JSONResponse(
+        status_code=actions_resp.status_code,
+        content=actions_resp.json(),
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,7 @@ import responses
 from fastapi.testclient import TestClient
 
 from preClinVar.__version__ import VERSION
-from preClinVar.constants import DRY_RUN_SUBMISSION_URL, VALIDATE_SUBMISSION_URL
+from preClinVar.constants import DRY_RUN_SUBMISSION_URL, SUBMISSION_URL, VALIDATE_SUBMISSION_URL
 from preClinVar.demo import (
     casedata_old_csv,
     casedata_old_csv_path,
@@ -367,7 +367,7 @@ def test_apitest_status():
         responses.GET,
         f"{VALIDATE_SUBMISSION_URL}/{DEMO_SUBMISSION_ID}/actions/",
         json={"actions": actions},
-        status=200,  # The ClinVar API returns code 201 when request is successful (created)
+        status=200,
     )
 
     # GIVEN a call to the apitest_status endpoint
@@ -379,3 +379,35 @@ def test_apitest_status():
     assert response.status_code == 200
     assert response.json()["actions"][0]["id"]
     assert response.json()["actions"][0]["responses"][0]["files"]
+
+
+@responses.activate
+def test_status_submitted():
+    """Test the status endpoint, proxy to the https://submit.ncbi.nlm.nih.gov/api/v1/submissions/SUBnnnnnn/actions ClinVar endpoint."""
+
+    # GIVEN a mocked submitted response from ClinVar:
+    actions: list[dict] = [
+        {
+            "id": f"{DEMO_SUBMISSION_ID}-1",
+            "responses": [],
+            "status": "submitted",
+            "targetDb": "clinvar",
+            "updated": "2024-04-26T13:39:24.384085Z",
+        }
+    ]
+
+    responses.add(
+        responses.GET,
+        f"{SUBMISSION_URL}/{DEMO_SUBMISSION_ID}/actions/",
+        json={"actions": actions},
+        status=200,
+    )
+
+    # GIVEN a call to the status endpoint
+    response = client.post(
+        "/status", data={"api_key": DEMO_API_KEY, "submission_id": DEMO_SUBMISSION_ID}
+    )
+
+    # THEN the response should contain the provided actions
+    assert response.status_code == 200
+    assert response.json()["actions"][0]["status"] == "submitted"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -408,6 +408,6 @@ def test_status_submitted():
         "/status", data={"api_key": DEMO_API_KEY, "submission_id": DEMO_SUBMISSION_ID}
     )
 
-    # THEN the response should contain the provided actions
+    # THEN the response should contain the provided status
     assert response.status_code == 200
     assert response.json()["actions"][0]["status"] == "submitted"


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #125

### How to test:
- Automatic tests

### Expected outcome:
- [x] All tests shouls pass

### Review:
- [ ] Code approved by
- [x] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
