### PR TITLE
Add  a test for the /delete endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## [unreleased]
 ### Added
-- Delete submission endpoint, with json example (under demo files)
+- Delete submission endpoint, with json example (under demo files) and test
 ### Changed
 - Updated API submission schema to the latest available on `ncbi/clinvar` GitHub pages
 - Modified the json submission example to use one from the ClinVar GitHib repo (`sample_clinical_significance_hgvs_submission.json`)

--- a/preClinVar/main.py
+++ b/preClinVar/main.py
@@ -10,11 +10,7 @@ from fastapi.responses import JSONResponse
 
 from preClinVar.__version__ import VERSION
 from preClinVar.build import build_header, build_submission
-from preClinVar.constants import (
-    DRY_RUN_SUBMISSION_URL,
-    SUBMISSION_URL,
-    VALIDATE_SUBMISSION_URL,
-)
+from preClinVar.constants import DRY_RUN_SUBMISSION_URL, SUBMISSION_URL, VALIDATE_SUBMISSION_URL
 from preClinVar.file_parser import csv_lines, file_fields_to_submission, tsv_lines
 from preClinVar.validate import validate_submission
 
@@ -241,7 +237,7 @@ async def status(api_key: str = Form(), submission_id: str = Form()) -> JSONResp
 
 @app.post("/delete")
 async def delete(api_key: str = Form(), clinvar_accession: str = Form()):
-    """A proxy to the dry run submission ClinVar API endpoint"""
+    """A proxy to the submission ClinVar API, to delete a submission with a given ClinVar accession."""
     # Create a submission header
     header = build_header(api_key)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,6 +37,7 @@ OPTIONAL_PARAMETERS = {
     "assertionCriteriaDB": "PubMed",
     "assertionCriteriaID": "25741868",
 }
+DEMO_ACCESSION_ID = "SCV005395965"
 
 
 def test_heartbeat():
@@ -411,3 +412,25 @@ def test_status_submitted():
     # THEN the response should contain the provided status
     assert response.status_code == 200
     assert response.json()["actions"][0]["status"] == "submitted"
+
+
+@responses.activate
+def test_delete():
+    """Test the endpoint that deletes ClinVar submissions sing the API."""
+
+    # GIVEN a mocked submitted response from ClinVar:
+    responses.add(
+        responses.POST,
+        SUBMISSION_URL,
+        json={"id": DEMO_SUBMISSION_ID},
+        status=201,
+    )
+
+    # GIVEN a call to the delete endpoint
+    response = client.post(
+        "/delete", data={"api_key": DEMO_API_KEY, "clinvar_accession": DEMO_ACCESSION_ID}
+    )
+
+    # THEN the response should contain the provided status
+    assert response.status_code == 201
+    assert response.json()["id"] == DEMO_SUBMISSION_ID


### PR DESCRIPTION
## Description

### Added
- Test for the /delete endpoint

### How to test
- [x] Automatic tests

### Expected test outcome
- [x] All tests should pass

## Review
- [x] Tests executed by GitHub actions

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions