### PR TITLE
Minor release 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [2.8]
 ### Added
 - `validate` endpoint, accepting germline or somatic json submissions and supporting validation against the official schema
 ### Changed

--- a/preClinVar/__version__.py
+++ b/preClinVar/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "2.7.1"
+VERSION = "2.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "preClinVar"
-version = "2.7.1"
+version = "2.8.0"
 description = "A ClinVar API submission helper written in FastAPI"
 authors = ["Chiara Rasi <rasi.chiara@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## [2.8]
### Added
- `validate` endpoint, accepting germline or somatic json submissions and supporting validation against the official schema
### Changed
- Improve README and endpoint descriptions specifying that `tsv_2_json` and `csv_2_json` endpoints support only conversion for germline submission files
- PR template to be more compact and user friendly
### Fixed
- GitHub action to use poetry v.1.7.1

## Review
- [x] Tests executed by CR

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions