### PR TITLE
Patch release 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [2.8.1]
 ### Fixed
 - Remap chromosome `M` to `MT`, which is the accepted format from ClinVar API
 

--- a/preClinVar/__version__.py
+++ b/preClinVar/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "2.8"
+VERSION = "2.8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "preClinVar"
-version = "2.8.0"
+version = "2.8.1"
 description = "A ClinVar API submission helper written in FastAPI"
 authors = ["Chiara Rasi <rasi.chiara@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## [2.8.1]
### Fixed
- Remap chromosome `M` to `MT`, which is the accepted format from ClinVar API

## Review
- [x] Tests executed by GitHub actions

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions